### PR TITLE
WIP fix specs

### DIFF
--- a/spec/isolation/without_hanami_validations_spec.rb
+++ b/spec/isolation/without_hanami_validations_spec.rb
@@ -17,11 +17,7 @@ RSpec.describe "Without validations" do
 
   it "doesn't have params DSL" do
     expect do
-      Class.new(Hanami::Action) do
-        params do
-          required(:id).filled
-        end
-      end
+      WithoutHanamiValidations::Default.new.call({})
     end.to raise_error(
       NoMethodError,
       /To use `params`, please add 'hanami\/validations' gem to your Gemfile/
@@ -29,24 +25,18 @@ RSpec.describe "Without validations" do
   end
 
   it "has params that don't respond to .valid?" do
-    action = Class.new(Hanami::Action) do
-      def handle(req, res)
-        res.body = [req.params.respond_to?(:valid?), req.params.valid?]
-      end
-    end
+    action = WithoutHanamiValidations::NoParamsBlockValidCheck.new
 
-    response = action.new.call({})
+    response = action.call({})
+
     expect(response.body).to eq(["[true, true]"])
   end
 
   it "has params that don't respond to .errors" do
-    action = Class.new(Hanami::Action) do
-      def handle(req, res)
-        res.body = req.params.respond_to?(:errors)
-      end
-    end
+    action = WithoutHanamiValidations::NoParamsBlockErrorsCheck.new
 
-    response = action.new.call({})
+    response = action.call({})
+
     expect(response.body).to eq(["false"])
   end
 end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1551,6 +1551,36 @@ module SessionsWithoutCookies
   end
 end
 
+module Formats
+  class Lookup < Hanami::Action
+    def handle(*)
+    end
+  end
+
+  class Custom < Hanami::Action
+    def handle(req, res)
+      input = req.params[:format]
+      input = input.to_sym unless input.nil?
+
+      res.format = input
+    end
+  end
+
+  class Configuration < Hanami::Action
+    config.format :jpg
+
+    def handle(*, res)
+      res.body = res.format
+    end
+  end
+end
+
+module CsrfProtection
+  class Default < Hanami::Action
+    include Hanami::Action::CSRFProtection
+  end
+end
+
 module Mimes
   class Default < Hanami::Action
     def handle(_req, res)
@@ -1899,6 +1929,26 @@ module Inheritance
 
     def call(env)
       @routes.call(env)
+    end
+  end
+end
+
+module WithoutHanamiValidations
+  class Default < Hanami::Action
+    params do
+      required(:id).filled
+    end
+  end
+
+  class NoParamsBlockValidCheck < Hanami::Action
+    def handle(req, res)
+      res.body = [req.params.respond_to?(:valid?), req.params.valid?]
+    end
+  end
+
+  class NoParamsBlockErrorsCheck < Hanami::Action
+    def handle(req, res)
+      res.body = req.params.respond_to?(:errors)
     end
   end
 end

--- a/spec/unit/hanami/action/csrf_protection_spec.rb
+++ b/spec/unit/hanami/action/csrf_protection_spec.rb
@@ -2,9 +2,7 @@
 
 RSpec.describe Hanami::Action::CSRFProtection do
   subject(:action) {
-    Class.new(Hanami::Action) {
-      include Hanami::Action::CSRFProtection
-    }.new
+    CsrfProtection::Default.new
   }
 
   let(:response) { action.(request) }

--- a/spec/unit/hanami/action/format_spec.rb
+++ b/spec/unit/hanami/action/format_spec.rb
@@ -1,32 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::Action do
-  class FormatController
-    class Lookup < Hanami::Action
-      def handle(*)
-      end
-    end
-
-    class Custom < Hanami::Action
-      def handle(req, res)
-        input = req.params[:format]
-        input = input.to_sym unless input.nil?
-
-        res.format = input
-      end
-    end
-
-    class Configuration < Hanami::Action
-      config.format :jpg
-
-      def handle(*, res)
-        res.body = res.format
-      end
-    end
-  end
 
   describe "#format" do
-    let(:action) { FormatController::Lookup.new }
+    let(:action) { Formats::Lookup.new }
 
     it "lookup to #content_type if was not explicitly set (default: application/octet-stream)" do
       response = action.call({})
@@ -65,7 +42,7 @@ RSpec.describe Hanami::Action do
     # Bug
     # See https://github.com/hanami/controller/issues/167
     it "accepts '*/*' and returns configured default format" do
-      action = FormatController::Configuration.new
+      action = Formats::Configuration.new
       response = action.call("HTTP_ACCEPT" => "*/*")
 
       expect(response.format).to                  eq(:jpg)
@@ -85,7 +62,7 @@ RSpec.describe Hanami::Action do
   end
 
   describe "#format=" do
-    let(:action) { FormatController::Custom.new }
+    let(:action) { Formats::Custom.new }
 
     it "sets :all and returns 'application/octet-stream'" do
       response = action.call(format: "all")


### PR DESCRIPTION
Deal with multiple errors:
```
Hanami::ComponentLoadError:
        Class Hanami::Action must be defined within an Hanami app
```

In specs.

Also discovered a problem with spec/isolation/without_hanami_validations_spec.rb spec that fails (also before the change) because validations seem to be loaded despite the isolated spec context.

![image](https://github.com/krzykamil/controller/assets/25006471/cda11e44-4455-468e-8ed1-10992c5cb0f8)
